### PR TITLE
fix: remove dead audio previews, repair auth/session flow, add refresh & CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches-ignore: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check & build
+        run: npm run build

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sproxs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
 - 🔐 **Spotify OAuth 2.0 (PKCE)** — secure login with no server-side secrets
 - 🎵 **Playlist browser** — pick any playlist you own or follow
 - 🖱️ **Drag & Drop** — move tracks between tiers with smooth animations
-- 🔊 **Audio previews** — tap a track tile to hear a 30-second preview
 - 💾 **Offline persistence** — rankings stored in IndexedDB via localForage
+- 🔄 **Refresh** — re-sync a playlist's tracks from Spotify on demand
 - 📸 **Export as image** — download your tier list as a PNG
 - 📤 **Share** — native Web Share API with clipboard fallback
 - 📱 **Installable PWA** — add to home screen on mobile or desktop

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#121212" />
+    <link rel="icon" href="/pwa-192x192.svg" type="image/svg+xml" />
     <title>SpotRanker</title>
     <!-- SPA redirect handler for GitHub Pages 404 fallback -->
     <script>

--- a/src/config/spotify.ts
+++ b/src/config/spotify.ts
@@ -3,8 +3,7 @@ export const SPOTIFY_CONFIG = {
   redirectUri: import.meta.env.VITE_SPOTIFY_REDIRECT_URI as string ?? `${window.location.origin}${import.meta.env.BASE_URL}callback`,
   scopes: [
     'playlist-read-private',
-    'playlist-read-collaborative',
-    'user-read-private'
+    'playlist-read-collaborative'
   ],
   authorizeUrl: 'https://accounts.spotify.com/authorize',
   tokenUrl: 'https://accounts.spotify.com/api/token',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -32,8 +32,12 @@ const router = createRouter({
 router.beforeEach((to) => {
   if (to.meta.requiresAuth) {
     const token = localStorage.getItem('sp_access_token');
+    const refreshToken = localStorage.getItem('sp_refresh_token');
     const expiresAt = Number(localStorage.getItem('sp_expires_at')) || 0;
-    if (!token || Date.now() >= expiresAt) {
+    // An expired access token is fine as long as a refresh token exists –
+    // the API layer refreshes silently on the first request.
+    const hasValidSession = !!token && (Date.now() < expiresAt || !!refreshToken);
+    if (!hasValidSession) {
       return { name: 'home' };
     }
   }

--- a/src/services/spotifyApi.ts
+++ b/src/services/spotifyApi.ts
@@ -23,7 +23,6 @@ interface RawAlbum {
 interface RawTrack {
   id: string | null;
   name?: string;
-  preview_url?: string | null;
   artists?: RawArtist[];
   album?: RawAlbum;
 }
@@ -137,7 +136,7 @@ export async function fetchPlaylistTracks(playlistId: string): Promise<SpotifyTr
 
   while (hasMore) {
     const data = await apiFetch<SpotifyPaginatedResponse<RawPlaylistItem>>(
-      `/playlists/${playlistId}/items?limit=${limit}&offset=${offset}&fields=items(item(id,name,preview_url,artists(name),album(name,images))),total,limit,offset,next`,
+      `/playlists/${playlistId}/items?limit=${limit}&offset=${offset}&fields=items(item(id,name,artists(name),album(name,images))),total,limit,offset,next`,
     );
 
     for (const item of data.items) {
@@ -181,7 +180,6 @@ function mapTrack(raw: RawPlaylistItem, playlistId: string): SpotifyTrack | null
     artist: artists.map((a) => a.name).join(', ') || 'Unbekannter Künstler',
     albumName: track.album?.name ?? '',
     albumCoverUrl: images.length > 0 ? images[0].url : null,
-    previewUrl: track.preview_url ?? null,
     playlistId,
   };
 }

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -28,7 +28,11 @@ export const useAuthStore = defineStore('auth', () => {
   // ---------------------------------------------------------------------------
   // Computed
   // ---------------------------------------------------------------------------
-  const isAuthenticated = computed(() => !!accessToken.value && Date.now() < expiresAt.value);
+  // An expired access token still counts as authenticated when a refresh
+  // token exists – getAccessToken() refreshes silently before the next call.
+  const isAuthenticated = computed(
+    () => !!accessToken.value && (Date.now() < expiresAt.value || !!refreshToken.value),
+  );
   const tokenNeedsRefresh = computed(() => !!accessToken.value && Date.now() >= expiresAt.value - 5 * 60 * 1000);
 
   // ---------------------------------------------------------------------------

--- a/src/stores/playlists.ts
+++ b/src/stores/playlists.ts
@@ -74,17 +74,27 @@ export const usePlaylistStore = defineStore('playlists', () => {
     cachedPlaylistIds.value = await getCachedPlaylistIds();
   }
 
-  /** Load tracks for a specific playlist – uses cache if available, fetches if needed. */
-  async function loadTracks(playlistId: string): Promise<void> {
+  /**
+   * Load tracks for a specific playlist – uses cache if available, fetches if
+   * needed. With `forceRefresh` the cache is bypassed and overwritten; if the
+   * network fails, cached tracks are kept as a fallback.
+   * Returns where the tracks came from.
+   */
+  async function loadTracks(
+    playlistId: string,
+    options?: { forceRefresh?: boolean },
+  ): Promise<'cache' | 'network' | 'error'> {
     isLoadingTracks.value = true;
     error.value = null;
 
     try {
-      // 1. Try IndexedDB first (offline-first)
-      const cached = await loadPlaylistTracks(playlistId);
-      if (cached && cached.length > 0) {
-        currentTracks.value = cached;
-        return;
+      // 1. Try IndexedDB first (offline-first), unless a refresh is forced
+      if (!options?.forceRefresh) {
+        const cached = await loadPlaylistTracks(playlistId);
+        if (cached && cached.length > 0) {
+          currentTracks.value = cached;
+          return 'cache';
+        }
       }
 
       // 2. Fetch from API
@@ -94,9 +104,20 @@ export const usePlaylistStore = defineStore('playlists', () => {
       // 3. Persist to IndexedDB for offline use
       await savePlaylistTracks(playlistId, apiTracks);
       cachedPlaylistIds.value = await getCachedPlaylistIds();
+      return 'network';
     } catch (e) {
+      // Forced refresh gone wrong (e.g. offline) – fall back to the cache
+      // instead of wiping the editor.
+      if (options?.forceRefresh) {
+        const cached = await loadPlaylistTracks(playlistId);
+        if (cached && cached.length > 0) {
+          currentTracks.value = cached;
+          return 'cache';
+        }
+      }
       error.value = e instanceof Error ? e.message : 'Tracks konnten nicht geladen werden.';
       currentTracks.value = [];
+      return 'error';
     } finally {
       isLoadingTracks.value = false;
     }

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -15,7 +15,6 @@ export interface SpotifyTrack {
   artist: string;
   albumName: string;
   albumCoverUrl: string | null;
-  previewUrl: string | null;
   playlistId: string;
 }
 

--- a/src/views/EditorView.vue
+++ b/src/views/EditorView.vue
@@ -141,6 +141,17 @@ async function executeSave(ranking: RankingData): Promise<void> {
   isSaving = false;
 }
 
+function buildRanking(): RankingData {
+  return {
+    S: tierData.S.map((t) => t.id),
+    A: tierData.A.map((t) => t.id),
+    B: tierData.B.map((t) => t.id),
+    C: tierData.C.map((t) => t.id),
+    D: tierData.D.map((t) => t.id),
+    unranked: tierData.unranked.map((t) => t.id),
+  };
+}
+
 function debouncedSave(): void {
   if (saveTimer !== null) {
     clearTimeout(saveTimer);
@@ -148,16 +159,8 @@ function debouncedSave(): void {
   }
   saveTimer = setTimeout(() => {
     saveTimer = null;
-    const ranking: RankingData = {
-      S: tierData.S.map((t) => t.id),
-      A: tierData.A.map((t) => t.id),
-      B: tierData.B.map((t) => t.id),
-      C: tierData.C.map((t) => t.id),
-      D: tierData.D.map((t) => t.id),
-      unranked: tierData.unranked.map((t) => t.id),
-    };
     // Fire-and-forget: executeSave handles errors internally
-    void executeSave(ranking);
+    void executeSave(buildRanking());
   }, 500);
 }
 
@@ -282,55 +285,33 @@ async function shareImage(): Promise<void> {
 const shareTooltip = ref('');
 
 // ---------------------------------------------------------------------------
-// Audio Preview (with proper cleanup to prevent memory leaks)
+// Manual refresh – bypass the track cache and re-hydrate the tier list
 // ---------------------------------------------------------------------------
-const currentAudio = ref<HTMLAudioElement | null>(null);
-const currentPreviewId = ref<string | null>(null);
-let audioEndedHandler: (() => void) | null = null;
+const isRefreshing = ref(false);
 
-function togglePreview(track: SpotifyTrack): void {
-  if (!track.previewUrl) return;
+async function refreshTracks(): Promise<void> {
+  if (isRefreshing.value || store.isLoadingTracks) return;
+  isRefreshing.value = true;
 
-  // If clicking the same track that's already playing, stop it
-  if (currentPreviewId.value === track.id) {
-    stopPreview();
-    return;
-  }
-
-  // Stop any existing preview
-  stopPreview();
-
-  const audio = new Audio(track.previewUrl);
-  audio.volume = 0.5;
-
-  audioEndedHandler = () => {
-    currentPreviewId.value = null;
-    currentAudio.value = null;
-    audioEndedHandler = null;
-  };
-  audio.addEventListener('ended', audioEndedHandler);
-
-  audio.play().catch((err) => {
-    console.error('[EditorView] Audio preview failed:', err);
-    stopPreview();
-  });
-
-  currentAudio.value = audio;
-  currentPreviewId.value = track.id;
-}
-
-function stopPreview(): void {
-  if (currentAudio.value) {
-    if (audioEndedHandler) {
-      currentAudio.value.removeEventListener('ended', audioEndedHandler);
-      audioEndedHandler = null;
+  try {
+    // Persist the current ranking immediately so re-hydration uses fresh state
+    if (saveTimer !== null) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
     }
-    currentAudio.value.pause();
-    currentAudio.value.removeAttribute('src');
-    currentAudio.value.load();
-    currentAudio.value = null;
+    await executeSave(buildRanking());
+
+    initialPopulationDone.value = false;
+    const source = await store.loadTracks(props.playlistId, { forceRefresh: true });
+
+    if (source === 'network') {
+      showStatus('Playlist aktualisiert.');
+    } else if (source === 'cache') {
+      showStatus('Keine Verbindung – zeige zwischengespeicherte Tracks.');
+    }
+  } finally {
+    isRefreshing.value = false;
   }
-  currentPreviewId.value = null;
 }
 
 onBeforeUnmount(() => {
@@ -343,7 +324,6 @@ onBeforeUnmount(() => {
     clearTimeout(statusTimer);
     statusTimer = null;
   }
-  stopPreview();
 });
 
 onMounted(() => {
@@ -361,6 +341,15 @@ onMounted(() => {
 
       <!-- Action buttons -->
       <div v-if="!store.isLoadingTracks && !store.error" class="flex flex-wrap gap-2">
+        <button
+          :disabled="isRefreshing"
+          class="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs font-semibold text-zinc-200 transition hover:border-zinc-500 hover:text-white disabled:opacity-50"
+          @click="refreshTracks"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" :class="{ 'animate-spin': isRefreshing }" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
+          {{ isRefreshing ? 'Aktualisiere…' : 'Aktualisieren' }}
+        </button>
+
         <button
           :disabled="isExporting"
           class="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs font-semibold text-zinc-200 transition hover:border-zinc-500 hover:text-white disabled:opacity-50"
@@ -460,19 +449,6 @@ onMounted(() => {
                     loading="lazy"
                   />
                   <div v-else class="flex h-full items-center justify-center text-xl text-zinc-600">🎵</div>
-
-                  <!-- Audio preview button -->
-                  <button
-                    v-if="element.previewUrl"
-                    class="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition group-hover/tile:opacity-100"
-                    :class="{ '!opacity-100': currentPreviewId === element.id }"
-                    @click.stop="togglePreview(element)"
-                  >
-                    <!-- Play icon -->
-                    <svg v-if="currentPreviewId !== element.id" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white drop-shadow" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"/></svg>
-                    <!-- Pause icon -->
-                    <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-spotify-400 drop-shadow" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-                  </button>
                 </div>
                 <div class="p-1">
                   <p class="truncate text-[10px] font-semibold text-white">{{ element.name }}</p>
@@ -524,17 +500,6 @@ onMounted(() => {
                     loading="lazy"
                   />
                   <div v-else class="flex h-full items-center justify-center text-xl text-zinc-600">🎵</div>
-
-                  <!-- Audio preview button -->
-                  <button
-                    v-if="element.previewUrl"
-                    class="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition group-hover/tile:opacity-100"
-                    :class="{ '!opacity-100': currentPreviewId === element.id }"
-                    @click.stop="togglePreview(element)"
-                  >
-                    <svg v-if="currentPreviewId !== element.id" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white drop-shadow" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"/></svg>
-                    <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-spotify-400 drop-shadow" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-                  </button>
                 </div>
                 <div class="p-1">
                   <p class="truncate text-[10px] font-semibold text-white">{{ element.name }}</p>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -36,7 +36,6 @@ function goToDashboard() {
           Login with Spotify
         </BaseButton>
         <BaseButton v-else @click="goToDashboard">Zum Dashboard</BaseButton>
-        <BaseButton variant="secondary" @click="router.push('/editor/demo')">Demo öffnen</BaseButton>
       </div>
 
       <p v-if="auth.error" class="rounded-lg border border-red-800/60 bg-red-950/40 px-3 py-2 text-sm text-red-300">


### PR DESCRIPTION
- Remove audio preview feature: Spotify removed preview_url with the
  Feb 2026 Web API changes, so the play buttons could never work
- Drop the requested-but-unused user-read-private OAuth scope
- Remove the broken demo button (route was auth-guarded)
- Treat sessions with a refresh token as authenticated so users are no
  longer bounced to the login page every hour
- Add a refresh button in the tier editor that bypasses the track cache
  (falls back to cache when offline)
- Add favicon link to silence the 404 on every page load
- Add CI workflow (type-check + build on PRs), LICENSE (MIT), README update

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VeajxaMKXfaz1hF9bPVsK8