### PR TITLE
ci: migrate Cloudflare Pages deploys to wrangler-action and validate Spotify client ID

### DIFF
--- a/.github/workflows/cloudflare-pages-staging.yml
+++ b/.github/workflows/cloudflare-pages-staging.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          SPOTIFY_CLIENT_ID: ${{ secrets.VITE_SPOTIFY_CLIENT_ID }}
           SPOTIFY_REDIRECT_URI_STAGING: ${{ secrets.VITE_SPOTIFY_REDIRECT_URI_STAGING }}
         run: |
           if [ -z "$CF_API_TOKEN" ]; then
@@ -32,6 +33,12 @@ jobs:
           if [ -z "$CF_ACCOUNT_ID" ]; then
             echo "❌ CLOUDFLARE_ACCOUNT_ID secret is not configured."
             echo "   Go to GitHub → Settings → Secrets and variables → Actions → New repository secret"
+            echo "   See CLOUDFLARE_DEPLOYMENT.md for detailed setup instructions."
+            exit 1
+          fi
+          if [ -z "$SPOTIFY_CLIENT_ID" ]; then
+            echo "❌ VITE_SPOTIFY_CLIENT_ID secret is not configured."
+            echo "   Without it the site deploys, but Spotify login will not work."
             echo "   See CLOUDFLARE_DEPLOYMENT.md for detailed setup instructions."
             exit 1
           fi
@@ -74,18 +81,15 @@ jobs:
 
       - name: Deploy to Cloudflare Pages (Staging)
         id: deploy
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: spotranker-staging
-          directory: dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          branch: staging
+          command: pages deploy dist --project-name=spotranker-staging --branch=staging
 
       - name: Verify deployment URL
         run: |
-          DEPLOY_URL="${{ steps.deploy.outputs.url }}"
+          DEPLOY_URL="${{ steps.deploy.outputs.deployment-url }}"
           if [ -z "$DEPLOY_URL" ]; then
             echo "⚠️  No deployment URL returned. Check Cloudflare Pages dashboard manually."
             exit 0

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          SPOTIFY_CLIENT_ID: ${{ secrets.VITE_SPOTIFY_CLIENT_ID }}
         run: |
           if [ -z "$CF_API_TOKEN" ]; then
             echo "❌ CLOUDFLARE_API_TOKEN secret is not configured."
@@ -31,6 +32,12 @@ jobs:
           if [ -z "$CF_ACCOUNT_ID" ]; then
             echo "❌ CLOUDFLARE_ACCOUNT_ID secret is not configured."
             echo "   Go to GitHub → Settings → Secrets and variables → Actions → New repository secret"
+            echo "   See CLOUDFLARE_DEPLOYMENT.md for detailed setup instructions."
+            exit 1
+          fi
+          if [ -z "$SPOTIFY_CLIENT_ID" ]; then
+            echo "❌ VITE_SPOTIFY_CLIENT_ID secret is not configured."
+            echo "   Without it the site deploys, but Spotify login will not work."
             echo "   See CLOUDFLARE_DEPLOYMENT.md for detailed setup instructions."
             exit 1
           fi
@@ -68,17 +75,15 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         id: deploy
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: spotranker
-          directory: dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy dist --project-name=spotranker
 
       - name: Verify deployment URL
         run: |
-          DEPLOY_URL="${{ steps.deploy.outputs.url }}"
+          DEPLOY_URL="${{ steps.deploy.outputs.deployment-url }}"
           if [ -z "$DEPLOY_URL" ]; then
             echo "⚠️  No deployment URL returned. Check Cloudflare Pages dashboard manually."
             exit 0

--- a/CLOUDFLARE_DEPLOYMENT.md
+++ b/CLOUDFLARE_DEPLOYMENT.md
@@ -11,7 +11,7 @@ Every push to the `main` branch triggers the **Deploy to Cloudflare Pages** GitH
 1. Installs Node.js 20 and project dependencies.
 2. Builds the Vite app (`npm run build`) and injects environment variables from GitHub Secrets.
 3. Verifies that the `dist/` output directory and `dist/index.html` exist.
-4. Deploys the `dist/` folder to Cloudflare Pages using [`cloudflare/pages-action`](https://github.com/cloudflare/pages-action).
+4. Deploys the `dist/` folder to Cloudflare Pages using [`cloudflare/wrangler-action`](https://github.com/cloudflare/wrangler-action) (`wrangler pages deploy`).
 5. Checks the live deployment URL for an HTTP 200 response as a post-deployment smoke test.
 
 ---
@@ -148,7 +148,7 @@ If the smoke test returns a non-200 status the workflow still succeeds (the site
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Workflow fails with `Input required and not supplied: apiToken` | `CLOUDFLARE_API_TOKEN` or `CLOUDFLARE_ACCOUNT_ID` secret is missing | Add both secrets under **Settings → Secrets and variables → Actions** (see One-Time Setup above) |
+| Workflow fails at the "Check required secrets" step | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, or `VITE_SPOTIFY_CLIENT_ID` secret is missing | Add the missing secrets under **Settings → Secrets and variables → Actions** (see One-Time Setup above) |
 | Build fails with type errors | TypeScript compile error | Run `npm run type-check` locally and fix errors |
 | Cloudflare deployment step fails | Missing or invalid secrets | Re-check `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` |
 | Assets return 404 after deploy | Wrong Vite base path | Ensure the `CF_PAGES_BUILD: 'true'` env var is set in both Cloudflare workflows' build steps — this tells Vite to use base `/` instead of `/SpotRanker/` |


### PR DESCRIPTION
## Hintergrund

Bei der Untersuchung, warum das Cloudflare-Pages-Deployment nicht funktioniert, hat sich gezeigt: die Ursache liegt **nicht** im Repository. Alle bisherigen Workflow-Läufe scheitern im ersten Step `Check required secrets`, weil die GitHub-Secrets `CLOUDFLARE_API_TOKEN` und `CLOUDFLARE_ACCOUNT_ID` nicht gesetzt sind — Build und Deploy wurden nie erreicht. Das muss einmalig im Repository-Setting nachgeholt werden (siehe `CLOUDFLARE_DEPLOYMENT.md`).

Bei der Analyse sind zwei Probleme in den Workflows selbst aufgefallen, die dieser PR behebt.

## Änderungen

**1. Weg von `cloudflare/pages-action@v1`**

Die Action ist von Cloudflare deprecated. Beide Workflows nutzen jetzt `cloudflare/wrangler-action@v3` mit `wrangler pages deploy dist --project-name=…`. Der Smoke-Test liest die URL entsprechend aus `steps.deploy.outputs.deployment-url` statt `outputs.url`. Die Staging-Variante behält ihr `--branch=staging`.

Da die Deployments über die API laufen, entfällt der bisher übergebene `gitHubToken` — die GitHub-Deployment-Verknüpfung war für den eigentlichen Upload nicht erforderlich.

**2. `VITE_SPOTIFY_CLIENT_ID` wird jetzt geprüft**

Fehlte dieses Secret, lief der Build durch und die Seite wurde deployt — nur mit kaputtem Spotify-Login, was erst beim manuellen Testen auffällt. Der Secret-Check bricht jetzt in beiden Workflows früh ab, analog zu den bestehenden Cloudflare-Checks.

**3. Doku nachgezogen**

`CLOUDFLARE_DEPLOYMENT.md` nennt jetzt die neue Action, und die Troubleshooting-Zeile zum fehlenden API-Token beschreibt den tatsächlich auftretenden Fehler (Abbruch im `Check required secrets`-Step statt `Input required and not supplied: apiToken`) inklusive des neuen Client-ID-Checks.

## Verifikation

Die YAML-Syntax beider Workflows wurde geparst und ist valide. Ein echter End-to-End-Lauf ist erst möglich, sobald die Secrets im Repository hinterlegt sind — danach lässt sich der Workflow „Deploy to Cloudflare Pages" über den Actions-Tab per `workflow_dispatch` manuell starten; der Smoke-Test sollte HTTP 200 auf der `pages.dev`-URL melden.

## Was danach noch offen bleibt

Diese manuellen Schritte kann der PR nicht abnehmen:

1. Cloudflare-Pages-Projekt `spotranker` anlegen (Direct Upload)
2. API-Token mit Berechtigung „Cloudflare Pages: Edit" erstellen
3. Secrets setzen: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `VITE_SPOTIFY_CLIENT_ID`, `VITE_SPOTIFY_REDIRECT_URI`
4. Redirect-URI im Spotify Developer Dashboard registrieren

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeajxaMKXfaz1hF9bPVsK8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeajxaMKXfaz1hF9bPVsK8)_