### PR TITLE
chore: add project Claude Code settings with superpowers plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true
+  },
+
+  "extraKnownMarketplaces": {
+    "superpowers-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "obra/superpowers-marketplace"
+      }
+    }
+  },
+
+  "permissions": {
+    "allow": [
+      "Bash(npm ci)",
+      "Bash(npm install)",
+      "Bash(npm run build)",
+      "Bash(npm run type-check)",
+      "Bash(npm run dev)",
+      "Bash(npm run preview)",
+      "Bash(npx vue-tsc *)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(git branch*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git fetch*)",
+      "Bash(git checkout*)",
+      "Bash(git switch*)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.local)",
+      "Read(./.env.*.local)",
+      "Edit(./.env)",
+      "Bash(npx wrangler deploy*)",
+      "Bash(wrangler deploy*)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)"
+    ],
+    "ask": [
+      "Bash(git push*)",
+      "Bash(npm publish*)"
+    ]
+  },
+
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && [ -d node_modules ] || npm ci --no-audit --no-fund >/dev/null 2>&1 || true",
+            "timeout": 300,
+            "statusMessage": "Abhängigkeiten installieren…"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty'); case \"$f\" in *.ts|*.vue) cd \"$CLAUDE_PROJECT_DIR\" || exit 0; [ -d node_modules ] || exit 0; out=$(npx vue-tsc -b 2>&1) || { printf '%s\\n' \"$out\" | tail -40 >&2; exit 2; };; esac",
+            "timeout": 180,
+            "statusMessage": "TypeScript prüfen…"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .DS_Store
 *.local
 .env
+.claude/settings.local.json


### PR DESCRIPTION
Adds .claude/settings.json as the team-wide Claude Code configuration:

- Enables the superpowers plugin from the official marketplace and
  registers obra/superpowers-marketplace as a known source so its
  companion plugins can be installed without extra setup.
- Allows the four package.json scripts plus read/commit git commands
  without permission prompts; denies .env reads, wrangler deploy and
  destructive git operations; keeps git push behind a confirmation.
- SessionStart hook runs npm ci when node_modules is missing, so fresh
  containers can build and type-check.
- PostToolUse hook runs `vue-tsc -b` after edits to .ts/.vue files and
  feeds failures back instead of letting them surface only in CI. Note
  it uses `vue-tsc -b` rather than the `type-check` script: the root
  tsconfig.json has `files: []` with references only, so plain
  `vue-tsc --noEmit` checks zero files.

Also gitignores .claude/settings.local.json for personal overrides —
the existing `*.local` pattern does not match that filename.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XYnq1jz1sACepiwVb1Lt3q