### PR TITLE
feat: add PWA update flow with banner and manual check

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,18 @@
+# Cloudflare Workers static-assets header rules.
+#
+# The service worker and the HTML shell are the two files that gate every PWA
+# update: if an edge or browser cache serves a stale sw.js, the client-side
+# update check has nothing new to find. Hashed JS/CSS assets are immutable by
+# name and keep Cloudflare's default caching.
+#
+# Unrelated to the _redirects caveat in CLOUDFLARE_DEPLOYMENT.md — that one is a
+# separate mechanism and still must not exist.
+
+/sw.js
+  Cache-Control: no-cache
+
+/index.html
+  Cache-Control: no-cache
+
+/manifest.webmanifest
+  Cache-Control: no-cache

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
 import { RouterView } from 'vue-router';
 import AppNavbar from '@/components/ui/AppNavbar.vue';
 import ConsoleOverlay from '@/components/ui/ConsoleOverlay.vue';
+import UpdateBanner from '@/components/ui/UpdateBanner.vue';
 </script>
 
 <template>
@@ -15,5 +16,6 @@ import ConsoleOverlay from '@/components/ui/ConsoleOverlay.vue';
       </main>
     </div>
     <ConsoleOverlay />
+    <UpdateBanner />
   </div>
 </template>

--- a/src/components/ui/ConsoleOverlay.vue
+++ b/src/components/ui/ConsoleOverlay.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue';
+import { computed, ref, onMounted, onUnmounted } from 'vue';
 import { clearAllCaches } from '@/services/offlineDb';
+import { formatBuildInfo } from '@/config/buildInfo';
+import { usePwaUpdate, type UpdateCheckState } from '@/services/pwaUpdate';
 
 type LogLevel = 'log' | 'warn' | 'error';
 
@@ -113,6 +115,52 @@ const levelBadge: Record<LogLevel, string> = {
   error: 'bg-red-900/60 text-red-300',
 };
 
+// ---------------------------------------------------------------------------
+// PWA update check. State lives in the pwaUpdate singleton, so the label here
+// stays in sync with the update banner instead of running its own timer.
+// ---------------------------------------------------------------------------
+const { checkState, checkForUpdate, applyUpdate } = usePwaUpdate();
+
+const buildInfo = formatBuildInfo();
+
+const updateLabels: Record<UpdateCheckState, string> = {
+  idle: 'Check for Update',
+  checking: 'Checking…',
+  available: 'Update ready!',
+  'up-to-date': 'Up to date',
+  offline: 'Offline',
+  unsupported: 'Not in dev',
+  error: 'Check failed',
+};
+
+const updateLabel = computed(() => updateLabels[checkState.value]);
+
+const updateClass = computed(() => {
+  switch (checkState.value) {
+    case 'available':
+    case 'up-to-date':
+      return 'bg-green-900/60 text-green-300';
+    case 'error':
+      return 'bg-red-900/60 text-red-300';
+    case 'checking':
+    case 'offline':
+    case 'unsupported':
+      return 'text-zinc-600';
+    default:
+      return 'text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200';
+  }
+});
+
+function handleCheckForUpdate() {
+  if (checkState.value === 'checking') return;
+  // A second click on "Update ready!" applies it, same as the banner button.
+  if (checkState.value === 'available') {
+    void applyUpdate();
+    return;
+  }
+  void checkForUpdate();
+}
+
 async function handleClearCache() {
   try {
     await clearAllCaches();
@@ -152,6 +200,14 @@ async function handleClearCache() {
         <div class="flex items-center gap-2">
           <button
             class="rounded px-2 py-0.5 text-xs transition"
+            :class="updateClass"
+            :title="checkState === 'available' ? 'Apply the waiting update' : 'Check for a new app version'"
+            @click="handleCheckForUpdate"
+          >
+            {{ updateLabel }}
+          </button>
+          <button
+            class="rounded px-2 py-0.5 text-xs transition"
             :class="cacheCleared ? 'bg-green-900/60 text-green-300' : 'text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200'"
             @click="handleClearCache"
           >
@@ -181,6 +237,11 @@ async function handleClearCache() {
           <span class="min-w-0 break-all" :class="levelClass[entry.level]">{{ entry.message }}</span>
           <span class="ml-auto shrink-0 text-zinc-600">{{ entry.timestamp }}</span>
         </div>
+      </div>
+
+      <!-- Build stamp: makes it verifiable that an update actually landed. -->
+      <div class="border-t border-zinc-800 px-4 py-1.5 text-[10px] text-zinc-600">
+        Version {{ buildInfo }}
       </div>
     </div>
   </Transition>

--- a/src/components/ui/UpdateBanner.vue
+++ b/src/components/ui/UpdateBanner.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import BaseButton from '@/components/ui/BaseButton.vue';
+import { usePwaUpdate } from '@/services/pwaUpdate';
+
+const { needRefresh, applyUpdate } = usePwaUpdate();
+
+const dismissed = ref(false);
+const applying = ref(false);
+
+async function handleUpdate() {
+  applying.value = true;
+  try {
+    await applyUpdate();
+  } catch (err) {
+    console.error('[UpdateBanner] Update konnte nicht angewendet werden:', err);
+    applying.value = false;
+  }
+  // On success the page reloads, so `applying` is never reset here.
+}
+
+// Dismissing only hides the banner – the new worker keeps waiting and takes
+// over on the next cold start.
+function handleDismiss() {
+  dismissed.value = true;
+}
+</script>
+
+<template>
+  <!--
+    Anchored bottom-left: the ⚙ console FAB (bottom-4 right-4) and its panel
+    (bottom-16 right-4) both own the right edge. On narrow screens right-20
+    keeps the banner clear of the FAB.
+  -->
+  <Transition name="slide-up">
+    <div
+      v-if="needRefresh && !dismissed"
+      class="fixed bottom-4 left-4 right-20 z-40 rounded-xl border border-zinc-800 bg-zinc-900/90 p-4 shadow-2xl backdrop-blur-xl sm:right-auto sm:w-80"
+      role="status"
+    >
+      <p class="text-sm font-semibold text-white">Neue Version verfügbar</p>
+      <p class="mt-1 text-xs text-zinc-400">
+        Deine Rankings bleiben erhalten – die App lädt sich einmal neu.
+      </p>
+
+      <div class="mt-3 flex items-center gap-2">
+        <BaseButton class="!px-3 !py-1.5 !text-xs" :disabled="applying" @click="handleUpdate">
+          {{ applying ? 'Aktualisiere…' : 'Jetzt aktualisieren' }}
+        </BaseButton>
+        <button
+          class="rounded-lg px-3 py-1.5 text-xs font-semibold text-zinc-400 transition hover:bg-zinc-800 hover:text-zinc-200"
+          @click="handleDismiss"
+        >
+          Später
+        </button>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.slide-up-enter-active,
+.slide-up-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.slide-up-enter-from,
+.slide-up-leave-to {
+  opacity: 0;
+  transform: translateY(8px);
+}
+</style>

--- a/src/config/buildInfo.ts
+++ b/src/config/buildInfo.ts
@@ -1,0 +1,27 @@
+// Build identity for the ⚙ overlay. The values come from the `define` block in
+// vite.config.ts, which vitest.config.ts does NOT replicate – hence the typeof
+// guards, so importing this module from a test yields 'dev' instead of throwing
+// a ReferenceError.
+export const APP_VERSION = typeof __APP_VERSION__ === 'undefined' ? 'dev' : __APP_VERSION__;
+export const BUILD_TIME = typeof __BUILD_TIME__ === 'undefined' ? '' : __BUILD_TIME__;
+
+/**
+ * Human-readable build stamp, e.g. `a1b2c3d · 11.08.2026, 22:14`.
+ * Falls back to the bare version when the build time is missing or unparsable.
+ */
+export function formatBuildInfo(version: string = APP_VERSION, iso: string = BUILD_TIME): string {
+  if (!iso) return version;
+
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return version;
+
+  const stamp = date.toLocaleString('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return `${version} · ${stamp}`;
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/vue" />
+
+// Injected by the `define` block in vite.config.ts. Never read these directly –
+// go through src/config/buildInfo.ts, which guards the Vitest case where no
+// define block exists.
+declare const __APP_VERSION__: string;
+declare const __BUILD_TIME__: string;

--- a/src/services/pwaUpdate.ts
+++ b/src/services/pwaUpdate.ts
@@ -1,0 +1,166 @@
+import { computed, ref } from 'vue';
+import { useRegisterSW } from 'virtual:pwa-register/vue';
+
+// ---------------------------------------------------------------------------
+// Service-Worker update controller.
+//
+// This is deliberately a module singleton, NOT a composable: useRegisterSW()
+// registers the service worker as a side effect, so calling it from two
+// components would register twice. The update banner and the ⚙ overlay button
+// share this one instance.
+//
+// Dev note: under `npm run dev`, `virtual:pwa-register/vue` resolves to a no-op
+// stub – onRegisteredSW never fires and needRefresh stays false, so the button
+// reports 'unsupported'. Exercise this against `npm run build && npm run
+// preview`, which serves a real service worker.
+// ---------------------------------------------------------------------------
+
+export type UpdateCheckState =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'up-to-date'
+  | 'offline'
+  | 'unsupported'
+  | 'error';
+
+/** Background poll while the tab stays alive. */
+const AUTO_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+/** Upper bound on waiting for a new worker to finish installing. */
+const INSTALL_TIMEOUT_MS = 15_000;
+/** How long a transient result ("Up to date", "Offline", …) stays on the button. */
+const RESULT_RESET_MS = 4_000;
+/** Safety net in case the SW never sends its `controlling` event. */
+const RELOAD_FALLBACK_MS = 3_000;
+
+const checkState = ref<UpdateCheckState>('idle');
+
+let registration: ServiceWorkerRegistration | undefined;
+let inFlight: Promise<UpdateCheckState> | null = null;
+let resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+const { needRefresh, offlineReady, updateServiceWorker } = useRegisterSW({
+  immediate: true,
+  onRegisteredSW(_swUrl, swRegistration) {
+    registration = swRegistration;
+    if (!swRegistration) return;
+
+    // An installed PWA typically goes to the background instead of being
+    // closed, so it may never cold-start and never re-fetch sw.js on its own.
+    // These two triggers are what actually make updates arrive.
+    setInterval(() => {
+      void checkForUpdate({ silent: true });
+    }, AUTO_CHECK_INTERVAL_MS);
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        void checkForUpdate({ silent: true });
+      }
+    });
+  },
+  onRegisterError(err) {
+    console.error('[pwaUpdate] Service Worker konnte nicht registriert werden:', err);
+    checkState.value = 'error';
+  },
+});
+
+function setState(state: UpdateCheckState): void {
+  if (resetTimer !== null) {
+    clearTimeout(resetTimer);
+    resetTimer = null;
+  }
+  checkState.value = state;
+
+  // 'available' is the only sticky result – it stays until the user acts on it.
+  if (state === 'idle' || state === 'checking' || state === 'available') return;
+
+  resetTimer = setTimeout(() => {
+    resetTimer = null;
+    checkState.value = 'idle';
+  }, RESULT_RESET_MS);
+}
+
+/**
+ * Background checks must not make the button flicker through
+ * "Checking…" → "Up to date" while nobody asked for it, so they only surface a
+ * result when an update is actually waiting.
+ */
+function settle(state: UpdateCheckState, silent: boolean): UpdateCheckState {
+  if (!silent || state === 'available') setState(state);
+  return state;
+}
+
+/**
+ * `registration.update()` resolves once the new sw.js has been fetched and the
+ * install has *started* – not when it has finished. Without this wait,
+ * `registration.waiting` is still empty right after and a real update would be
+ * reported as "Up to date".
+ */
+function waitForInstall(reg: ServiceWorkerRegistration): Promise<void> {
+  const installing = reg.installing;
+  if (!installing) return Promise.resolve();
+
+  return new Promise<void>((resolve) => {
+    function finish(): void {
+      clearTimeout(timer);
+      installing!.removeEventListener('statechange', onStateChange);
+      resolve();
+    }
+
+    function onStateChange(): void {
+      const state = installing!.state;
+      if (state === 'installed' || state === 'activated' || state === 'redundant') finish();
+    }
+
+    const timer = setTimeout(finish, INSTALL_TIMEOUT_MS);
+    installing.addEventListener('statechange', onStateChange);
+  });
+}
+
+async function runCheck(silent: boolean): Promise<UpdateCheckState> {
+  if (!registration) return settle('unsupported', silent);
+  if (!navigator.onLine) return settle('offline', silent);
+
+  if (!silent) setState('checking');
+
+  try {
+    await registration.update();
+    await waitForInstall(registration);
+    const available = Boolean(registration.waiting) || needRefresh.value;
+    return settle(available ? 'available' : 'up-to-date', silent);
+  } catch (err) {
+    console.error('[pwaUpdate] Update-Prüfung fehlgeschlagen:', err);
+    return settle('error', silent);
+  }
+}
+
+/** Ask the browser to re-fetch sw.js. Concurrent calls share one check. */
+export function checkForUpdate(options: { silent?: boolean } = {}): Promise<UpdateCheckState> {
+  if (inFlight) return inFlight;
+
+  inFlight = runCheck(options.silent ?? false).finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+/**
+ * Hand control to the waiting worker. vite-plugin-pwa's prompt path already
+ * attaches a `controlling` listener that reloads the page, so the timer below
+ * only covers the case where that event never arrives.
+ */
+export async function applyUpdate(): Promise<void> {
+  window.setTimeout(() => window.location.reload(), RELOAD_FALLBACK_MS);
+  await updateServiceWorker(true);
+}
+
+export function usePwaUpdate() {
+  return {
+    /** True once a new worker is waiting – drives the update banner. */
+    needRefresh,
+    offlineReady,
+    checkState: computed(() => checkState.value),
+    checkForUpdate,
+    applyUpdate,
+  };
+}

--- a/tests/frontend/buildInfo.test.ts
+++ b/tests/frontend/buildInfo.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { APP_VERSION, BUILD_TIME, formatBuildInfo } from '@/config/buildInfo';
+
+describe('buildInfo', () => {
+  it('falls back to "dev" when the vite define block is absent', () => {
+    // vitest.config.ts intentionally does not replicate vite.config.ts's
+    // `define`, so importing this module must not throw a ReferenceError.
+    expect(APP_VERSION).toBe('dev');
+    expect(BUILD_TIME).toBe('');
+  });
+
+  it('combines version and build time', () => {
+    const result = formatBuildInfo('a1b2c3d', '2026-08-11T20:14:00.000Z');
+    expect(result.startsWith('a1b2c3d · ')).toBe(true);
+    expect(result).toContain('2026');
+  });
+
+  it('returns the bare version when the build time is missing', () => {
+    expect(formatBuildInfo('a1b2c3d', '')).toBe('a1b2c3d');
+  });
+
+  it('returns the bare version when the build time is unparsable', () => {
+    expect(formatBuildInfo('a1b2c3d', 'not-a-date')).toBe('a1b2c3d');
+  });
+
+  it('uses the module defaults when called without arguments', () => {
+    expect(formatBuildInfo()).toBe('dev');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,34 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { VitePWA } from 'vite-plugin-pwa';
+import { execSync } from 'node:child_process';
 import path from 'node:path';
 
 // Cloudflare serves the app from the root of its own hostname.
 const base = '/';
 
+// Build identity, surfaced in the ⚙ overlay so a user can tell at a glance
+// whether an update actually landed. Cloudflare Workers Builds clones the repo
+// (so git works) but also exports the SHA directly – prefer the env var, since
+// a shallow/detached checkout can make `git rev-parse` unreliable.
+function resolveVersion(): string {
+  const ci = process.env.WORKERS_CI_COMMIT_SHA ?? process.env.CF_PAGES_COMMIT_SHA;
+  if (ci) return ci.slice(0, 7);
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return 'dev';
+  }
+}
+
 export default defineConfig({
   base,
+  define: {
+    __APP_VERSION__: JSON.stringify(resolveVersion()),
+    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+  },
   // In dev, the scraper Worker runs separately (`npm run dev:worker` →
   // wrangler dev on :8787). Proxy /api there so the browser's same-origin
   // relative calls reach it with clean HMR for the SPA.
@@ -19,7 +40,15 @@ export default defineConfig({
   plugins: [
     vue(),
     VitePWA({
-      registerType: 'autoUpdate',
+      // 'prompt', not 'autoUpdate': with autoUpdate the plugin forces
+      // skipWaiting + clientsClaim, so a freshly deployed SW activates
+      // immediately, drops the previous precache and takes over the *open*
+      // page – which keeps running the old JS. Every lazy route chunk
+      // (src/router/index.ts) then 404s, because Cloudflare removes the old
+      // hashed assets on deploy. Prompt mode keeps the new SW in `waiting`
+      // until src/services/pwaUpdate.ts applies it with a controlled reload,
+      // so the version swap is atomic.
+      registerType: 'prompt',
       manifest: {
         name: 'SpotRanker',
         short_name: 'SpotRanker',
@@ -44,6 +73,13 @@ export default defineConfig({
         ]
       },
       workbox: {
+        // These three are Workbox defaults under registerType 'prompt', but
+        // spelled out on purpose: they are the whole point of the mode, and a
+        // silent flip back to 'autoUpdate' would otherwise reintroduce the
+        // mixed old-page/new-SW state described above.
+        skipWaiting: false,
+        clientsClaim: false,
+        cleanupOutdatedCaches: true,
         globPatterns: ['**/*.{js,css,html,ico,png,svg,webmanifest}'],
         // The scraper API is dynamic – never let the SPA navigation fallback
         // serve index.html for it, and never precache it.


### PR DESCRIPTION
Installed PWA instances stayed on old code after a deploy. The cause was
`registerType: 'autoUpdate'` combined with nothing in src/ importing
`virtual:pwa-register`: the plugin fell back to injecting a bare
`navigator.serviceWorker.register()` with no reload handling, while
autoUpdate forced skipWaiting + clientsClaim. A new worker therefore
activated at once, dropped the previous precache and claimed the open
page — which kept executing the old JS. Since every route is lazy, the
next navigation requested a chunk that no longer existed either in the
precache or on Cloudflare, and failed. Nothing ever called
registration.update(), so a standalone PWA that never cold-starts could
miss updates indefinitely.

Switch to `registerType: 'prompt'` so the new worker parks in `waiting`
until the user applies it, making the version swap atomic:

- src/services/pwaUpdate.ts: module singleton around useRegisterSW (a
  second call would register the worker twice). Checks hourly and on
  visibilitychange — the latter matters most, since an installed PWA is
  backgrounded rather than closed. Waits for the install to finish after
  update(), which otherwise resolves too early to see the new worker.
- src/components/ui/UpdateBanner.vue: "Neue Version verfügbar" prompt,
  anchored bottom-left to stay clear of the console FAB.
- src/components/ui/ConsoleOverlay.vue: "Check for Update" button driven
  by the shared state, plus a build stamp so an update is verifiable.
- vite.config.ts / src/config/buildInfo.ts: git SHA and build time via
  `define`, guarded for Vitest, which has no define block.
- public/_headers: keep sw.js and the HTML shell out of caches, so the
  client-side check has something new to find.

Verified against `vite preview` in Chromium: the page is uncontrolled on
first load and controlled after reload; a rebuild leaves the new worker
waiting while the old page keeps rendering and lazy routes still resolve
without chunk errors; the banner appears on returning to the foreground
without any click; applying it reloads once onto the new build; and an
offline check reports "Offline" instead of hanging.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HUyxn5gtsMQ8aLYVCngszr